### PR TITLE
Add ways to handle missing uniforms/attributes

### DIFF
--- a/src/program.ts
+++ b/src/program.ts
@@ -38,6 +38,14 @@ export type GLUniforms<Props = {}> = Record<
   GLUniformValue | ((props: Props) => GLUniformValue)
 >;
 
+export type MissingHandler = (msg: string)=>void;
+export const CommonMissingHandlers = {
+  "error": (msg: string)=>{throw new Error(msg);},
+  "warning": (msg: string)=>{console.warn(msg);},
+  "ignore": ()=>{}
+} as const satisfies Record<string,MissingHandler>;
+export type CommonMissingHandler = keyof typeof CommonMissingHandlers;
+
 export type GLProgramDefinition<Props extends {} = {}> = {
   vert?: string;
   frag?: string;
@@ -49,6 +57,7 @@ export type GLProgramDefinition<Props extends {} = {}> = {
   attributes?: GLAttributes<Props>;
   uniforms?: GLUniforms<Props>;
   blend?: GLBlendConfig;
+  missingHandler?: MissingHandler | CommonMissingHandler;
 };
 
 type GLProgramUniform<Props> = {
@@ -80,6 +89,7 @@ export class GLProgram<Props extends {} = {}> implements GLResource {
   private uniforms: Record<string, GLProgramUniform<Props>> = {};
   private attributes: Record<string, GLProgramAttribute<Props>> = {};
   private attributeCache = new Map<number, GLAttribute>();
+  private missingHandler: MissingHandler;
 
   static readonly DEFAULT_VERT = /* glsl */ `
     precision mediump float;
@@ -133,6 +143,12 @@ export class GLProgram<Props extends {} = {}> implements GLResource {
     this.offset = definition.offset ?? 0;
     this.indexType = definition.indexType ?? "uint16";
 
+    if (typeof definition.missingHandler == "function") {
+      this.missingHandler = definition.missingHandler;
+    } else {
+      this.missingHandler = CommonMissingHandlers[definition.missingHandler ?? "error"];
+    }
+
     this.handle = this.buildProgram(gl, vert, frag);
 
     if (definition.uniforms) {
@@ -149,7 +165,8 @@ export class GLProgram<Props extends {} = {}> implements GLResource {
     for (const [name, value] of Object.entries(uniforms)) {
       const location = gl.getUniformLocation(this.handle, name);
       if (!location) {
-        throw new Error(`Uniform not found: ${name}`);
+        this.missingHandler(`Uniform not found: ${name}`);
+        continue;
       }
       result[name] = { name, location, value };
     }
@@ -161,7 +178,8 @@ export class GLProgram<Props extends {} = {}> implements GLResource {
     for (const [name, value] of Object.entries(attributes)) {
       const location = gl.getAttribLocation(this.handle, name);
       if (location === -1) {
-        throw new Error(`Attribute not found: ${name}`);
+        this.missingHandler(`Attribute not found: ${name}`);
+        continue;
       }
       result[name] = { name, location, value };
     }


### PR DESCRIPTION
Currently, whenever an uniform or attribute is missing from the shader, there will be an Error thrown from the program constructor. Relevant bits of code:
https://github.com/roprgm/gl-lite/blob/cc660660608c13e8de27721ffd8e3844d1cc1144/src/program.ts#L147-L157
https://github.com/roprgm/gl-lite/blob/cc660660608c13e8de27721ffd8e3844d1cc1144/src/program.ts#L147-L157

This PR adds the `missingHandler` parameter to the GLProgramDefinition<T> type, with which you can specify how to handle such cases. I added support for specifying a function (handling the error yourself) and specifying a string for common behaviors. The common behaviors are:
- `"error"`: throws an Error the same way as it did previously (default)
- `"warning"`: prints a warning to the browser console using `console.warn()`
- `"ignore"`: do nothing and ignore

Example usage:
```ts
const fsh = `#version 300 es
precision mediump float;

out vec4 outColor;

void main() {
    // The uniform is not declared
    // or used at all
    outColor = vec4(1.0, 0.0, 0.0, 1.0);
}
`;

const renderer = ...;
const program = renderer.program({
  frag: fsh,

  uniforms: {
    unusedUniform: 42.0,
  },

  // Use the new missingHandler option
  missingHandler: "warning"
});
```

Perhaps the default option could be changed to `"warning"`, but I did not want to make that assumption myself.

The change is fully backwards compatible, and does not change any behavior.